### PR TITLE
feat(hud/office): integrate dynamic battery SVG with color, animation, and usage handling

### DIFF
--- a/assets/icons/batery_off.svg
+++ b/assets/icons/batery_off.svg
@@ -1,0 +1,5 @@
+<svg width="501" height="250" viewBox="0 0 501 250" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="484.224" y="81.5" width="16.2759" height="86" fill="white" stroke="white"/>
+<rect x="5" y="5" width="473.724" height="240" rx="45" stroke="white" stroke-width="10"/>
+<path d="M167.821 64L419.724 122.295L256.387 115.28L358.937 186L64 122.295L230.961 125.148L167.821 64Z" fill="#FF5B5B"/>
+</svg>

--- a/components/HUD/HUD.ejs
+++ b/components/HUD/HUD.ejs
@@ -1,5 +1,11 @@
 <div id="hud" class="content-hud">
-  <div id="battery">
+  <div id="battery" style="display: flex;align-items: center;gap: 5px;">
+    <svg width="100%" height="100%" viewBox="0 0 501 250" fill="none" xmlns="http://www.w3.org/2000/svg" id="battery-on">
+      <rect x="484.224" y="81.5" width="16.2759" height="86" fill="white" stroke="white" />
+      <rect x="5" y="5" width="473.724" height="240" rx="45" stroke="white" stroke-width="10" />
+      <rect x="32" y="32" width="419.724" height="186" fill="#48FF6A" id="battery_power" />
+    </svg>
+    <img id="battery-off" src="icons/batery_off.svg" style="display:none;">
     <span id="battery-value"></span>
   </div>
   <div id="time">

--- a/public/css/HUD.css
+++ b/public/css/HUD.css
@@ -7,3 +7,35 @@
     letter-spacing: 1px;
     margin: .5rem 1rem 0 1rem;
 }
+
+#battery svg {
+    width: 50px;
+    height: 20px;
+    transition: fill 0.5s linear;
+}
+
+#battery-value{
+    display: inline-block;
+    width: 3ch;
+    text-align: right;
+}
+
+#battery #battery-off {
+    width: 50px;
+    height: 20px;
+    animation: opacity 1s infinite;
+    ;
+    opacity: 1;
+}
+
+@keyframes opacity {
+
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0;
+    }
+}

--- a/public/js/HUD.js
+++ b/public/js/HUD.js
@@ -6,6 +6,9 @@ export default class HUD {
     this.battery = 100;
     this.time = "12 AM";
 
+    this.batteryON = document.getElementById("battery-on");
+    this.batteryBar = document.getElementById("battery_power");
+    this.batteryOffImg = document.getElementById("battery-off");
     this.batteryEl = document.getElementById("battery-value");
     this.timeEl = document.getElementById("time-value");
 
@@ -37,20 +40,84 @@ export default class HUD {
 
       if (this.time === "06 AM") {
         clearInterval(this.clockInterval);
-        this.game.setState(this.game.GAME_STATES.NEXT_DAY); // o lo que quieras
+        this.game.setState(this.game.GAME_STATES.NEXT_DAY);
       }
 
       index = (index + 1) % times.length;
     }, 30000);
   }
 
+  _getBatteryColor(percent) {
+    let start, end, rangeStart, rangeEnd;
+
+    if (percent >= 50) {
+      // verde → naranja (50-100%)
+      start = [72, 255, 106];   // #48FF6A
+      end = [241, 156, 27];     // #f19c1b
+      rangeStart = 100;
+      rangeEnd = 50;
+    } else {
+      // naranja → rojo (0-50%)
+      start = [241, 156, 27];   // #f19c1b
+      end = [245, 59, 59];      // #f53b3b
+      rangeStart = 50;
+      rangeEnd = 0;
+    }
+
+    const t = (percent - rangeStart) / (rangeEnd - rangeStart); // interpolación 0→1
+
+    const r = Math.round(start[0] + (end[0] - start[0]) * t);
+    const g = Math.round(start[1] + (end[1] - start[1]) * t);
+    const b = Math.round(start[2] + (end[2] - start[2]) * t);
+
+    return `rgb(${r},${g},${b})`;
+  }
+
   _updateUI() {
     this.batteryEl.textContent = `${this.battery}%`;
     this.timeEl.textContent = this.time;
+
+    // Calcular ancho dinámico
+    const maxWidth = 419.724;
+    const newWidth = (this.battery / 100) * maxWidth;
+
+    this.batteryBar.setAttribute("width", newWidth);
+
+    if (this.battery <= 0) {
+      this.batteryON.style.display = "none";
+      this.batteryOffImg.style.display = "block";
+
+      // Si aún no hicimos la animación final
+      if (!this._gameOverTriggered) {
+        this._gameOverTriggered = true; // flag para no repetir
+        clearInterval(this.batteryInterval); // parar consumo
+
+        // ⏳ esperar 3 segundos antes del GAME_OVER
+        setTimeout(() => {
+          this.game.setState(this.game.GAME_STATES.GAME_OVER);
+        }, 50000);
+      }
+    } else {
+      this.batteryON.style.display = "block";
+      this.batteryOffImg.style.display = "none";
+    }
+
+    // Cambiar color según nivel
+    if (this.battery > 0) {
+      const color = this._getBatteryColor(this.battery);
+      this.batteryBar.setAttribute("fill", color);
+    }
   }
 
   setTime(newTime) {
     this.time = newTime;
     this._updateUI();
+  }
+
+  useBattery(amount) {
+    if (this.battery <= 0) return;
+    this.battery = Math.max(0, this.battery - amount);
+    this._updateUI();
+
   }
 }

--- a/public/js/ofice.js
+++ b/public/js/ofice.js
@@ -17,23 +17,17 @@ export default class Office {
 
   openLeftDoor() {
     console.log("Left door clicked");
-    this.hud.battery -= 1;
-    this.hud._updateUI();
-    // lógica extra de puerta izquierda
+    this.hud.useBattery(1);
   }
 
   openRightDoor() {
     console.log("Right door clicked");
-    this.hud.battery -= 1;
-    this.hud._updateUI();
-    // lógica extra de puerta derecha
+    this.hud.useBattery(1);
   }
 
   openCameras() {
     console.log("Camera computer clicked");
-    this.hud.battery -= 2;
-    this.hud._updateUI();
-    // lógica para abrir el monitor de cámaras
+    this.hud.useBattery(4);
   }
 
   /** ----------------- INTERNAL METHODS ----------------- **/


### PR DESCRIPTION
This PR introduces a fully dynamic battery system with both visual and functional improvements across the HUD and Office modules.

Changes include:

**HUD improvements:**
- Added inline battery SVG (`battery-on`) with power bar (`battery_power`) and off-state icon (`battery-off`).
- Styled battery SVG with size, color transitions, and smooth fill animation.
- Implemented `_getBatteryColor` for interpolating battery color from green → orange → red.
- Updated `_updateUI` to dynamically adjust battery width, fill color, and handle off-state animation.
- Added `useBattery(amount)` method to decrease battery programmatically.

**Office improvements:**
- Replaced direct `hud.battery -= X` and `_updateUI()` calls with `hud.useBattery(amount)` to centralize battery logic.

**CSS updates:**
- Added battery SVG sizing, fill transition, and blinking animation for off-state icon.

These changes unify battery handling, improve visual feedback, and make it easier to manage battery usage across interactions.
