### PR TITLE
feat(i18n): add language support with JSON files, loader, and menu integration

### DIFF
--- a/components/menu_game/menu_game.ejs
+++ b/components/menu_game/menu_game.ejs
@@ -4,8 +4,9 @@
         <h1>SIGNAL LOST</h1>
     </div>
     <div class="menu__buttons">
-        <button id="playBtn">Comenzar Partida</button>
-        <button id="CreditsBtn">Creditos</button>
-        <button id="exitBtn">salir</button>
+        <button id="playBtn" data-i18n="menu.title_gamestart"></button>
+        <button id="settingsBtn" data-i18n="menu.title_settings"></button>
+        <button id="CreditsBtn" data-i18n="menu.title_credits"></button>
+        <button id="exitBtn" data-i18n="menu.exit"></button>
     </div>
 </div>

--- a/public/js/lang.js
+++ b/public/js/lang.js
@@ -1,0 +1,26 @@
+export let translations = {};
+
+export async function loadLang() {
+    const lang = localStorage.getItem("language") || "en";
+    const res = await fetch(`./lang/${lang}.json`);
+    translations = await res.json();
+    updateTexts();
+}
+
+export function updateTexts() {
+    document.querySelectorAll("[data-i18n]").forEach(el => {
+        const key = el.getAttribute("data-i18n");
+        const text = getNestedTranslation(key);
+        if (Array.isArray(text)) el.innerText = text.join("\n");
+        else if (typeof text === "string") el.innerText = text;
+    });
+}
+
+export function setLanguage(lang) {
+    localStorage.setItem("language", lang);
+    loadLang();
+}
+
+function getNestedTranslation(key) {
+    return key.split(".").reduce((obj, i) => obj?.[i], translations);
+}

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1,0 +1,13 @@
+{
+  "menu": {
+    "title_gamestart": "Start Game",
+    "title_settings": "Settings",
+    "title_credits": "Credits",
+    "exit": "Exit"
+  },
+  "settings": {
+    "title": "Settings",
+    "languageLabel": "Language:",
+    "back": "Back to Menu"
+  }
+}

--- a/public/lang/es.json
+++ b/public/lang/es.json
@@ -1,0 +1,13 @@
+{
+  "menu": {
+    "title_gamestart": "Comenzar Partida",
+    "title_settings": "Configuración",
+    "title_credits": "Créditos",
+    "exit": "Salir"
+  },
+  "settings": {
+    "title": "Configuración",
+    "languageLabel": "Idioma:",
+    "back": "Volver al menú"
+  }
+}


### PR DESCRIPTION
This PR introduces full internationalization support for the game interface:

- Added lang.js module to handle language loading, updating texts dynamically, and persisting language choice.
- Updated game menu (menu_game.ejs) to include data-i18n attributes for all button labels.
- Added initial JSON language files for English and Spanish in /lang folder.
- Prepared the structure to easily extend translations to more languages in the future.

With this change, the game can now dynamically switch languages, improving accessibility and user experience.
