### PR TITLE
feat(settings): add settings screen with language switcher and config integration

### DIFF
--- a/components/menu_game/menu_game.ejs
+++ b/components/menu_game/menu_game.ejs
@@ -4,8 +4,9 @@
         <h1>SIGNAL LOST</h1>
     </div>
     <div class="menu__buttons">
-        <button id="playBtn">Comenzar Partida</button>
-        <button id="CreditsBtn">Creditos</button>
-        <button id="exitBtn">salir</button>
+        <button id="playBtn" data-i18n="menu.title_gamestart"></button>
+        <button id="settingsBtn" data-i18n="menu.title_settings"></button>
+        <button id="CreditsBtn" data-i18n="menu.title_credits"></button>
+        <button id="exitBtn" data-i18n="menu.exit"></button>
     </div>
 </div>

--- a/components/settings/settings.ejs
+++ b/components/settings/settings.ejs
@@ -1,0 +1,11 @@
+<div id="settings" class="settings" style="display:none;">
+    <h1 data-i18n="settings.title"></h1>
+
+    <div>
+        <label data-i18n="settings.languageLabel"></label>
+        <button id="lang-en-btn">English</button>
+        <button id="lang-es-btn">Español</button>
+    </div>
+
+    <button id="back-menu-btn" data-i18n="settings.back"></button>
+</div>

--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -1,0 +1,33 @@
+.settings{
+    width: 100%;
+    height: 100%;
+    background: black;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    color: white;
+}
+.settings h1{
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+    letter-spacing: 1px;
+}
+.settings div label{
+    display: block;
+    margin-bottom: .5rem;
+}
+.settings div button{
+    background: none;
+    outline: none;
+    border: none;
+    color: white;
+    margin-inline: 1rem;
+}
+.settings #back-menu-btn{
+    margin-top: auto;
+    color: white;
+    background: none;
+    outline: none;
+    border: none;
+    text-transform: uppercase;
+}

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -2,7 +2,7 @@
 @import url(warning_screen.css);
 @import url(ofice.css);
 @import url(HUD.css);
-
+@import url(settings.css);
 :root{
     --primary-color:#fff;
     --secundary-color:#000;

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -2,6 +2,7 @@ export const GAME_STATES ={
     MENU: "menu",
     WARNING: "warning",
     OFFICE: "office",
+    SETTINGS: "Settings",
     CREDITS: "credits",
     NEXT_DAY: "next_day",
     GAME_OVER: "game_over"

--- a/public/js/lang.js
+++ b/public/js/lang.js
@@ -1,0 +1,26 @@
+export let translations = {};
+
+export async function loadLang() {
+    const lang = localStorage.getItem("language") || "en";
+    const res = await fetch(`./lang/${lang}.json`);
+    translations = await res.json();
+    updateTexts();
+}
+
+export function updateTexts() {
+    document.querySelectorAll("[data-i18n]").forEach(el => {
+        const key = el.getAttribute("data-i18n");
+        const text = getNestedTranslation(key);
+        if (Array.isArray(text)) el.innerText = text.join("\n");
+        else if (typeof text === "string") el.innerText = text;
+    });
+}
+
+export function setLanguage(lang) {
+    localStorage.setItem("language", lang);
+    loadLang();
+}
+
+function getNestedTranslation(key) {
+    return key.split(".").reduce((obj, i) => obj?.[i], translations);
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,12 +2,16 @@ import { startWarningSequence } from "./warning_screen.js";
 import Office from "./ofice.js";
 import { GAME_STATES } from "./config.js"
 import HUD from "./HUD.js";
-
+import { initSettings } from "./settings.js";
 
 export class game {
     constructor(config = {}) {
         // configuracion base del juego
-        this.config = {}
+        this.config = {
+            language: "en",
+            ...config
+        }
+
         this.GAME_STATES = GAME_STATES;
         // Estado global
         this.state = GAME_STATES.MENU;
@@ -17,9 +21,11 @@ export class game {
         this.sectionMenu = document.getElementById('menu_game')
         this.sectionWarning = document.getElementById('warning_screen')
         this.sectionOffice = document.getElementById('ofice')
+        this.sectionConfig = document.getElementById('settings')
 
         // botones
         this.btnPlay = document.getElementById('playBtn')
+        this.btnSettings = document.getElementById('settingsBtn')
         this.btnCredits = document.getElementById('CreditsBtn')
         this.btnExit = document.getElementById('exitBtn')
 
@@ -28,9 +34,13 @@ export class game {
 
         // inicializar eventos de menu
         this._initMenu()
+
+        initSettings(this);
     }
+
     _initMenu() {
         this.btnPlay.addEventListener('click', () => this.start());
+        this.btnSettings.addEventListener('click', () => this.showSettings());
         this.btnCredits.addEventListener('click', () => this.showCredits());
         this.btnExit.addEventListener('click', () => this.exitGame());
     }
@@ -43,6 +53,7 @@ export class game {
         this.sectionMenu.style.display = 'none';
         this.sectionWarning.style.display = 'none';
         this.sectionOffice.style.display = 'none';
+        this.sectionConfig.style.display = 'none';
 
         switch (newState) {
             case this.GAME_STATES.MENU:
@@ -55,6 +66,10 @@ export class game {
 
             case this.GAME_STATES.OFFICE:
                 this.sectionOffice.style.display = 'block';
+                break;
+
+            case this.GAME_STATES.SETTINGS:
+                this.sectionConfig.style.display = "flex"
                 break;
 
             case this.GAME_STATES.CREDITS:
@@ -89,6 +104,11 @@ export class game {
 
         this.hud = new HUD(this);
         this.Office = new Office(this.hud);
+    }
+
+    showSettings(){
+        console.log("mostrando configuracion");
+        this.setState(GAME_STATES.SETTINGS)
     }
 
     showCredits() {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -1,0 +1,23 @@
+import { setLanguage, loadLang } from "./lang.js";
+
+export function initSettings(gameInstance) {
+
+    // Botones de idioma
+    document.getElementById("lang-en-btn").addEventListener("click", () => {
+        gameInstance.config.language = "en";
+        setLanguage("en");
+    });
+
+    document.getElementById("lang-es-btn").addEventListener("click", () => {
+        gameInstance.config.language = "es";
+        setLanguage("es");
+    });
+
+    // Botón volver al menú
+    document.getElementById("back-menu-btn").addEventListener("click", () => {
+        gameInstance.setState(gameInstance.GAME_STATES.MENU);
+    });
+
+    // Inicializar idioma al abrir Settings
+    loadLang();
+}

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1,0 +1,13 @@
+{
+  "menu": {
+    "title_gamestart": "Start Game",
+    "title_settings": "Settings",
+    "title_credits": "Credits",
+    "exit": "Exit"
+  },
+  "settings": {
+    "title": "Settings",
+    "languageLabel": "Language:",
+    "back": "Back to Menu"
+  }
+}

--- a/public/lang/es.json
+++ b/public/lang/es.json
@@ -1,0 +1,13 @@
+{
+  "menu": {
+    "title_gamestart": "Comenzar Partida",
+    "title_settings": "Configuración",
+    "title_credits": "Créditos",
+    "exit": "Salir"
+  },
+  "settings": {
+    "title": "Configuración",
+    "languageLabel": "Idioma:",
+    "back": "Volver al menú"
+  }
+}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -9,6 +9,9 @@
 <body style="overflow: hidden;">
     <%- include('menu_game/menu_game') %>
 
+    <!-- SECTION SETTINGS -->
+    <%- include('settings/settings') %>
+    
     <!-- WARNING SCREEN -->
     <%- include('warning_screen/warning_screen') %>
 


### PR DESCRIPTION
This PR implements the Settings feature in the game:

- Added settings.js module to handle the settings screen and language switching.
- Created Settings panel markup (settings.ejs) and linked it in the main layout.
- Added CSS styles for the settings panel for proper display and UI consistency.
- Updated GAME_STATES and game.js to include SETTINGS state and navigation.
- Integrated buttons for English and Spanish selection, and back-to-menu functionality.
- Ensured the language selection updates dynamically using the i18n system.

This completes the first iteration of the Settings feature, allowing players to change language preferences and navigate seamlessly to/from the menu.
